### PR TITLE
Fix group-level-vbm

### DIFF
--- a/brainprep/utils/utils.py
+++ b/brainprep/utils/utils.py
@@ -433,7 +433,7 @@ def parse_bids_keys(
     # Extract modality (suffix before extension)
     suffix_pattern = (
         r"_(?P<modality>[a-zA-Z0-9]+)(?=\.(nii|nii\.gz|json|tsv|edf|vhdr"
-        r"|eeg|bvec|bval|csv))"
+        r"|eeg|bvec|bval|csv|mat|xml))"
     )
     modality_match = re.search(suffix_pattern, filename)
     if modality_match:

--- a/brainprep/utils/utils.py
+++ b/brainprep/utils/utils.py
@@ -501,7 +501,7 @@ def check_run(
         r"(?P<entity>(run))"
         r"-(?P<value>[^_/]+)"
     )
-    pattern = f"sub-*{entities['modality']}*{ext}"
+    pattern = f"*sub-*{entities['modality']}*{ext}"
 
     all_entities = []
     for bids_path_ in bids_path.parent.glob(pattern):
@@ -524,7 +524,7 @@ def check_run(
     all_run_ids = [item["run"] for item in all_entities]
     count = all_run_ids.count(entities["run"])
 
-    return count == 1
+    return count > 1
 
 
 def make_run_id(

--- a/brainprep/utils/utils.py
+++ b/brainprep/utils/utils.py
@@ -524,7 +524,7 @@ def check_run(
     all_run_ids = [item["run"] for item in all_entities]
     count = all_run_ids.count(entities["run"])
 
-    return count > 1
+    return count <= 1
 
 
 def make_run_id(


### PR DESCRIPTION
cat12vbm_morphometry uses parse_bids_keys while expecting .mat or .xml. Therefore, parse_bids_keys needs to allow them.