### PR TITLE
containers: Update morphologist version

### DIFF
--- a/containers/Dockerfile.sulcirec
+++ b/containers/Dockerfile.sulcirec
@@ -25,7 +25,6 @@ ENV PATH="/root/.pixi/bin:${PATH}"
 
 # Install: morphologist
 WORKDIR /opt/morphologist
-COPY headless.py /opt/morphologist/.pixi/envs/default/lib/python3.11/site-packages/soma/qt_gui/
 COPY pixi_morphologist.toml ./pixi.toml
 RUN pixi install
 RUN echo '#!/usr/bin/env bash' > /usr/local/bin/morphologist-wrapper \

--- a/containers/resources/pixi_morphologist.toml
+++ b/containers/resources/pixi_morphologist.toml
@@ -6,7 +6,7 @@ channels = [
 platforms = ["linux-64"]
 
 [dependencies]
-morphologist = "==6.0.13"
+morphologist = "==6.0.19"
 
 [activation.env]
 LD_PRELOAD = "/opt/morphologist/.pixi/envs/default/mesalib/lib/libglapi.so.0:/opt/morphologist/.pixi/envs/default/mesalib/lib/libGL.so.1"


### PR DESCRIPTION
Update the morphologist version.
PS: the replacement function (brainprep/interfaces/morphologist.py, l 209) is still needed.